### PR TITLE
fix: use absolut website links

### DIFF
--- a/open-positions/_posts/2025-04-02-circt-hdl-assistant.md
+++ b/open-positions/_posts/2025-04-02-circt-hdl-assistant.md
@@ -5,9 +5,9 @@ tag: student-assistant
 contact: tobias.woelfel@hm.edu
 ---
 
-For our research project [DI-OSVISE](/projects/osvise) we are looking for a
-motivated student to assist on the development of a Reduced Hardware Description
-Language for [CIRCT](https://circt.llvm.org/).
+For our research project [DI-OSVISE](https://aemy.cs.hm.edu/projects/osvise) we
+are looking for a motivated student to assist on the development of a Reduced
+Hardware Description Language for [CIRCT](https://circt.llvm.org/).
 
 Circuit IR Compilers and Tools (CIRCT) is a Multi-Level Intermediate
 Representation (MLIR) Framework based hardware compiler.

--- a/open-positions/_posts/2025-04-02-circt-hdl-theses.md
+++ b/open-positions/_posts/2025-04-02-circt-hdl-theses.md
@@ -5,9 +5,9 @@ tag: master
 contact: tobias.woelfel@hm.edu
 ---
 
-For our research project [DI-OSVISE](/projects/osvise) we are looking for a
-motivated student to research the possibility of a Reduced Hardware Description
-Language for [CIRCT](https://circt.llvm.org/).
+For our research project [DI-OSVISE](https://aemy.cs.hm.edu/projects/osvise) we
+are looking for a motivated student to research the possibility of a Reduced
+Hardware Description Language for [CIRCT](https://circt.llvm.org/).
 
 Circuit IR Compilers and Tools (CIRCT) is a Multi-Level Intermediate
 Representation (MLIR) Framework based hardware compiler.


### PR DESCRIPTION
The relative links do not work in the PDFs.
Instead of fixing the generation of the links automatically, just use fully qualified links instead.