### PR TITLE
feat: add news box with latest updates

### DIFF
--- a/assets/css/beautifuljekyll.css
+++ b/assets/css/beautifuljekyll.css
@@ -1099,3 +1099,33 @@ pre {
     display: inline-block;
   }
 }
+
+/* --- News Box --- */
+
+.news-box {
+  background-color: #f8f8f8;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+}
+
+.news-list {
+  list-style: none;
+  margin: 0.5rem 0 0 0;
+  padding-left: 0;
+}
+
+.news-item {
+  margin: 0.25rem 0;
+}
+
+.news-tag {
+  color: #808080;
+  font-size: 0.85rem;
+}
+
+.news-date {
+  color: #808080;
+  font-size: 0.85rem;
+}

--- a/index.md
+++ b/index.md
@@ -9,6 +9,53 @@ Hochschule München University of Applied Sciences. We are actively involved in
 research projects and education around the most important and innovative topics
 from deeply embedded systems to large scale computer systems.
 
+{% assign all_posts = site.posts | where_exp: "post", "post.layout == 'post' or post.layout == 'cross-post' or post.layout == 'job'" | sort: 'date' | reverse | slice: 0, 3 %}
+
+<div class="news-box">
+  <strong>Latest Updates:</strong>
+  <ul class="news-list">
+    {% for post in all_posts %}
+    <li class="news-item" data-date="{{ post.date | date: '%Y-%m-%d' }}">
+      <span class="news-tag">
+        {% if post.layout == 'job' %}[Job]{% elsif post.layout == 'cross-post' %}[Cross-Post]{% else %}[Post]{% endif %}
+      </span>
+      <a href="{% if post.layout == 'job' %}{{ post.url | absolute_url }}{% elsif post.layout == 'cross-post' %}{{ post.external_url }}{% else %}{{ post.url | absolute_url }}{% endif %}">
+        {{ post.title | strip_html | truncatewords: 8, "..." }}
+      </a>
+      <span class="news-date">
+        {% assign date_format = site.date_format | default: "%Y-%m-%d" %}
+        ({{ post.date | date: date_format }})
+      </span>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const newsItems = document.querySelectorAll('.news-item');
+  const oneMonthAgo = new Date();
+  oneMonthAgo.setDate(oneMonthAgo.getDate() - 30);
+
+  let visibleCount = 0;
+
+  newsItems.forEach(item => {
+    const dateText = item.getAttribute('data-date');
+    const itemDate = new Date(dateText);
+    if (itemDate < oneMonthAgo) {
+      item.style.display = 'none';
+    } else {
+      visibleCount++;
+    }
+  });
+
+  if (visibleCount === 0) {
+    const newsList = document.querySelector('.news-list');
+    newsList.innerHTML = '<li style="color: #808080; font-style: italic;">No updates in the last 30 days</li>';
+  }
+});
+</script>
+
 ### Research Topics
 
 Our current research focus covers the following areas.


### PR DESCRIPTION
Add a box with latest updates to the homepage.
Displays the 3 most recent entries from post and open positions. Uses tags '[Post]', '[Job]' and '[Cross-Post]' to categories the entries.
Hides items if they are older than 30 days.
Shows a message if there are no entries in the last 30 days.

Will look like this:

<img width="758" height="550" alt="image" src="https://github.com/user-attachments/assets/76b9f0f6-59f0-4518-8956-a3ba1d479cc1" />
